### PR TITLE
Add translation support

### DIFF
--- a/models/Entry.php
+++ b/models/Entry.php
@@ -8,7 +8,12 @@ use Model;
 class Entry extends Model
 {
     use \October\Rain\Database\Traits\Validation;
-    
+
+    /** @var array Translation support */
+    public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
+
+    public $translatable = ['entries'];
+
     /*
      * Validation
      */
@@ -22,4 +27,6 @@ class Entry extends Model
     
     
     protected $jsonable = ['entries'];
+
+
 }


### PR DESCRIPTION
This pull request adds translation support if Rainlab.Translation support is present. 

It is, however, not optimal since the repeater translation does not allow to translate single fields. Therefore, one has to refill all the member of staff when translating. 

It would be better if the position would be separated out from the repeater such that a translation could be applied to the position without refilling the names. But that would require major refactoring of the plugin, probably with breaking changes, so I'm not sure if you like to change it.